### PR TITLE
[New] UserStatTable 생성 & UserStatTable 조회

### DIFF
--- a/BackEnd/BackEndFederationAuth.cs
+++ b/BackEnd/BackEndFederationAuth.cs
@@ -1,5 +1,6 @@
 using BackEnd;
 using UnityEngine;
+using UnityEngine.UI;
 #if UNITY_ANDROID
 using GooglePlayGames;
 using GooglePlayGames.BasicApi;
@@ -10,6 +11,10 @@ public class BackEndFederationAuth : MonoBehaviour
 {
     [SerializeField] private GameObject GoogleLoginBtn;
     [SerializeField] private GameObject AppleLoginBtn;
+    [SerializeField] private GameObject LoginCanvas;
+    [SerializeField] private GameObject TapCanvs;
+    [SerializeField] private InputField InputField_Id; //에디터 환경 위해 임시 커스텀 로그인 환경 아이디필드
+    [SerializeField] private InputField InputField_Pw; 
     private void Awake()
     {
 #if UNITY_ANDROID
@@ -39,7 +44,9 @@ public class BackEndFederationAuth : MonoBehaviour
         BackendReturnObject bro = Backend.BMember.LoginWithTheBackendToken();
         if (bro.IsSuccess())
         {
-            Managers.Scene.LoadScene(Define.Scene.Main);
+            LoginCanvas.SetActive(false);
+            TapCanvs.SetActive(true);
+            //Managers.Scene.LoadScene(Define.Scene.Main);
             //BackendReturnObject bro2 = Backend.BMember.GetUserInfo();
             //string federationId = bro2.GetReturnValuetoJSON()["row"]["federationId"].ToString();
             //Debug.Log(federationId);
@@ -101,9 +108,12 @@ public class BackEndFederationAuth : MonoBehaviour
                     break;
                 case "201":
                     Debug.Log("신규 회원가입 완료.");
+    gameObject.GetComponent<BackEndGameInfo>().InsertUserStatDataTable();//유저 스탯 테이블 생성.
                     break;
             }
-            Managers.Scene.LoadScene(Define.Scene.Main);
+            //Managers.Scene.LoadScene(Define.Scene.Main);
+            LoginCanvas.SetActive(false);
+            TapCanvs.SetActive(true);
         }
         else //로그인 실패.
         {
@@ -137,7 +147,10 @@ public class BackEndFederationAuth : MonoBehaviour
         {
             //성공 처리
             Debug.Log("APPLE 로그인 성공");
-            Managers.Scene.LoadScene(Define.Scene.Main);
+            //Managers.Scene.LoadScene(Define.Scene.Main);
+            gameObject.GetComponent<BackEndGameInfo>().InsertUserStatDataTable();//유저 스탯 테이블 생성.
+            LoginCanvas.SetActive(false);
+            TapCanvs.SetActive(true);
         }
         else
         {
@@ -147,4 +160,25 @@ public class BackEndFederationAuth : MonoBehaviour
         }
     }
 #endif
+    //에디터 환경 개발 위한 커스텀 계정 회원가입 및 로그인 기능 (출시 시 삭제 예정)
+    public void OnClickCustomSignUp()
+    {
+        BackendReturnObject bro = Backend.BMember.CustomSignUp(InputField_Id.text, InputField_Pw.text);
+        if (bro.IsSuccess())
+        {
+            Debug.Log("회원가입에 성공했습니다");
+            gameObject.GetComponent<BackEndGameInfo>().InsertUserStatDataTable();//유저 스탯 테이블 생성.
+        }
+    }
+
+    public void OnClickCutomLogin()
+    {
+        BackendReturnObject bro = Backend.BMember.CustomLogin(InputField_Id.text, InputField_Pw.text);
+        if (bro.IsSuccess())
+        {
+            Debug.Log("로그인에 성공했습니다");
+            LoginCanvas.SetActive(false);
+            TapCanvs.SetActive(true);
+        }
+    }
 }

--- a/BackEnd/BackEndGameInfo.cs
+++ b/BackEnd/BackEndGameInfo.cs
@@ -1,0 +1,42 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using BackEnd;
+
+public class BackEndGameInfo : MonoBehaviour
+{
+    // Insert 는 '생성' 작업에 주로 사용된다. 
+    public void InsertUserStatDataTable()
+    {
+        // Param은 뒤끝 서버와 통신을 할 떄 넘겨주는 파라미터 클래스 입니다. 
+        Param param = new Param();
+
+        BackendReturnObject BRO = Backend.GameData.Insert("UserStatTable", param);
+
+        if (BRO.IsSuccess())
+        {
+            Debug.Log("indate : " + BRO.GetInDate());
+        }
+        else
+        {
+            switch (BRO.GetStatusCode())
+            {
+                case "404":
+                    Debug.Log("존재하지 않는 tableName인 경우");
+                    break;
+
+                case "412":
+                    Debug.Log("비활성화 된 tableName인 경우");
+                    break;
+
+                case "413":
+                    Debug.Log("하나의 row( column들의 집합 )이 400KB를 넘는 경우");
+                    break;
+
+                default:
+                    Debug.Log("서버 공통 에러 발생: " + BRO.GetMessage());
+                    break;
+            }
+        }
+    }
+}

--- a/BackEnd/BackEndGameInfo.cs.meta
+++ b/BackEnd/BackEndGameInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5641f90f2111a47a78dafbba7eddaeba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Function/TapManager.cs
+++ b/Function/TapManager.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+public class TapManager : MonoBehaviour
+{
+    public Text StartText;
+    void Start()
+    {
+        StartCoroutine(StartTextCon());
+    }
+    IEnumerator StartTextCon()
+    {
+        while (true)
+        {
+            StartText.gameObject.SetActive(true);
+            yield return new WaitForSeconds(0.3f);
+            StartText.gameObject.SetActive(false);
+            yield return new WaitForSeconds(0.3f);
+        }
+    }
+    private void Update()
+    {
+        if (Input.anyKeyDown)
+        {
+            Managers.Scene.LoadScene(Define.Scene.Main);
+        }
+    }
+}

--- a/Function/TapManager.cs.meta
+++ b/Function/TapManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 601482ff2c66d42209051b8c6d04628d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Manager/SoundManager.cs
+++ b/Manager/SoundManager.cs
@@ -7,7 +7,6 @@ public class SoundManager
     //MP3 player => AudioSource
     //MP3  음원 => AudioClip
     //관객(귀) =>AudioLister
-
     AudioSource[] _audioSources = new AudioSource[(int)Define.Sound.MaxCount];
     Dictionary<string, AudioClip> _audioClips = new Dictionary<string, AudioClip>(); //이펙트음 캐슁역할 위
 

--- a/Scenes/MainScene.cs
+++ b/Scenes/MainScene.cs
@@ -1,12 +1,21 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
+using BackEnd;
 
 public class MainScene : BaseScene
 {
+    [SerializeField] private Text Attack;
+    [SerializeField] private Text AttackSpeed;
+    [SerializeField] private Text MovingSpeed;
+    [SerializeField] private Text Hp;
+    [SerializeField] private Text Leadership;
+    [SerializeField] private Text Appeal;
     void Start()
     {
         Init();
+        InitUserStatTable();
     }
     protected override void Init()
     {
@@ -16,6 +25,46 @@ public class MainScene : BaseScene
     public override void Clear()
     {
         Debug.Log("MainScene Clear");
+    }
+    public void InitUserStatTable()
+    {
+        var bro = Backend.GameData.GetMyData("UserStatTable", new Where(), 10);
+        string OwnerIndate = "";
+        if (bro.IsSuccess() == false)
+        {
+            // 요청 실패 처리
+            Debug.Log(bro);
+            return;
+        }
+        if (bro.GetReturnValuetoJSON()["rows"].Count <= 0)
+        {
+            // 요청이 성공해도 where 조건에 부합하는 데이터가 없을 수 있기 때문에
+            // 데이터가 존재하는지 확인
+            // 위와 같은 new Where() 조건의 경우 테이블에 row가 하나도 없으면 Count가 0 이하 일 수 있다.
+            Debug.Log(bro);
+            return;
+        }
+        //내 테이블의 rowindate 할당.
+        for (int i = 0; i < bro.Rows().Count; ++i)
+        {
+            OwnerIndate = bro.Rows()[i]["updatedAt"]["S"].ToString();
+        }
+
+        string[] select = { "Attack", "AttackSpeed", "MovingSpeed","Hp","Leadership","Appeal" };
+
+        // 테이블 내 해당 rowIndate를 지닌 row를 조회
+        // select에 존재하는 컬럼만 리턴
+        var BRO = Backend.GameData.Get("UserStatTable", OwnerIndate, select); //BackEnd Return 데이터 Get.
+        var json = BRO.GetReturnValuetoJSON(); //BackEnd Return 데이ㅌ => JSON 데이터로 변환
+        PlayerData MyPlayerData = new PlayerData(json); //PlayerData 클래스에 할당.
+
+        //MainScene Text UI에 값 할당.
+        Attack.text = MyPlayerData.Attack.ToString();
+        AttackSpeed.text = MyPlayerData.AttackSpeed.ToString();
+        MovingSpeed.text = MyPlayerData.MovingSpeed.ToString();
+        Hp.text = MyPlayerData.Hp.ToString();
+        Leadership.text = MyPlayerData.Leadership.ToString();
+        Appeal.text = MyPlayerData.Appeal.ToString();
     }
     private void Update()
     {

--- a/Scenes/TitleScene.cs
+++ b/Scenes/TitleScene.cs
@@ -18,13 +18,4 @@ public class TitleScene : BaseScene
         //날려줄 정보들
         Debug.Log("TitleScene Clear");
     }
-
-    private void Update()
-    {
-        //임시로 씬넘겨주는 코드
-        if(Input.GetKeyDown(KeyCode.Q))
-        {
-            Managers.Scene.LoadScene(Define.Scene.Main);
-        }
-    }
 }

--- a/Utils/PlayerData.cs
+++ b/Utils/PlayerData.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+using LitJson;
+
+[Serializable]
+public class PlayerData
+{
+    public int Attack;
+    public int AttackSpeed;
+    public int MovingSpeed;
+    public int Hp;
+    public int Leadership;
+    public int Appeal;
+
+    public PlayerData(JsonData json) //JSON Data 할당 생성자.  
+    {
+        this.Attack = int.Parse(json["row"]["Attack"]["N"].ToString());
+        this.AttackSpeed = int.Parse(json["row"]["AttackSpeed"]["N"].ToString());
+        this.MovingSpeed = int.Parse(json["row"]["MovingSpeed"]["N"].ToString());
+        this.Hp = int.Parse(json["row"]["Hp"]["N"].ToString());
+        this.Leadership = int.Parse(json["row"]["Leadership"]["N"].ToString());
+        this.Appeal = int.Parse(json["row"]["Appeal"]["N"].ToString());
+    }
+}

--- a/Utils/PlayerData.cs.meta
+++ b/Utils/PlayerData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 952fb9513660d45e7ac53555f1364810
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description
뒤끝 BackEnd 에 생성해둔 테이블 UserStatTable에 로그인된 User에 Stat 적용.

1. 회원가입 시 Default 칼럼 생성문 작성 (유저 한명 당 하나의 테이블만 갖게 하기 위해)
2. MainScene에 넘어올 시 InitUserStatTable() 동작 => 뒤끝 UserStatTable의 본인 계정 칼럼의 Stat 정보 Get
3. Get 된 BackEnd Return Object => JSON 파싱
4. 파싱된 User Stat 정보 PlayerData Class에 할당.

### Reference
뒤끝 BackEnd 리턴 메소드 리스트 : https://www.notion.so/5ooh/BackEnd-UserStatTable-Insert-JSON-92b56ecd3a2b419f9b3cf1a3aff42583#dcaf3f44098b408c8a61334a733632f1

뒤끝 BackEnd 리턴 메소드 리스트:https://www.notion.so/5ooh/BackEnd-UserStatTable-Insert-JSON-92b56ecd3a2b419f9b3cf1a3aff42583#08e7925503bd49a58b1ee457d707a2d0