### PR TITLE
[Update] 포획,전리품 획득 로직 => 디비 연동 && 싱글톤 패턴 수정 && Unit 별 KillCount Table 연동.

### DIFF
--- a/BackEnd/BackEndGameInfo.cs
+++ b/BackEnd/BackEndGameInfo.cs
@@ -106,5 +106,4 @@ public class BackEndGameInfo : MonoBehaviour
             }
         }
     }
-
 }

--- a/BackEnd/BackEndGetTable.cs
+++ b/BackEnd/BackEndGetTable.cs
@@ -3,9 +3,6 @@ using BackEnd;
 
 public class BackEndGetTable : MonoBehaviour
 {
-    static BackEndGetTable s_instance; //유일성이 보장된다.
-    static BackEndGetTable Instance { get { Init(); return s_instance; } }
-
     public PlayerStatData playerStat;
     public PlayerAssetData playerAsset;
     public PlayerKillData playerKillData;
@@ -14,37 +11,17 @@ public class BackEndGetTable : MonoBehaviour
     private string AssetTableKey;
     private string CountTableKey;
 
-    private MainScene MainPage;
-
     private void Awake()
     {
-        Init(); //싱글톤 보장.
-
-
         InitUserStatTable(); //스탯 테이블 입력.
         InitUserAssetTable(); //자산 테이블 입력.
         InitCaptureCountTable(); //킬카운트 테이블 입력.
 
-        MainPage = GameObject.Find("@MainScene").GetComponent<MainScene>();//메인 페이지 갱신위한 클래스 할당.
+        //MainPage = GameObject.Find("@MainScene").GetComponent<MainScene>();//메인 페이지 갱신위한 클래스 할당.
 
         Debug.Log(StatTableKey);
         BackendReturnObject bro = Backend.BMember.GetUserInfo();
         playerStat.OwnerIndate = bro.GetReturnValuetoJSON()["row"]["inDate"].ToString();
-    }
-
-    static void Init()
-    {
-        if (s_instance == null)
-        {
-            GameObject go = GameObject.Find("UserTableInformation");
-            if (go == null)
-            {
-                go = new GameObject { name = "UserTableInformation" };
-                go.AddComponent<Managers>();
-            }
-            DontDestroyOnLoad(go);
-            s_instance = go.GetComponent<BackEndGetTable>();
-        }
     }
 
     //유저 스탯 테이블 init.
@@ -149,40 +126,6 @@ public class BackEndGetTable : MonoBehaviour
         CountTableKey = OwnerIndate;
     }
 
-    //포획 유닛 정보 Init
-    //public void InitCaptureUnitTable()
-    //{
-    //    var bro = Backend.GameData.GetMyData("OwnUnitTable", new Where(), 10);
-    //    string OwnerIndate = "";
-    //    if (bro.IsSuccess() == false)
-    //    {
-    //        // 요청 실패 처리
-    //        Debug.Log(bro);
-    //        return;
-    //    }
-    //    if (bro.GetReturnValuetoJSON()["rows"].Count <= 0)
-    //    {
-    //        // 요청이 성공해도 where 조건에 부합하는 데이터가 없을 수 있기 때문에
-    //        // 데이터가 존재하는지 확인
-    //        // 위와 같은 new Where() 조건의 경우 테이블에 row가 하나도 없으면 Count가 0 이하 일 수 있다.
-    //        Debug.Log(bro);
-    //        return;
-    //    }
-    //    //내 테이블의 rowindate 할당.
-    //    for (int i = 0; i < bro.Rows().Count; ++i)
-    //    {
-    //        OwnerIndate = bro.Rows()[i]["inDate"]["S"].ToString();
-    //    }
-    //    string[] select = {"Name"};
-
-    //    // 테이블 내 해당 rowIndate를 지닌 row를 조회
-    //    // select에 존재하는 컬럼만 리턴
-    //    var BRO = Backend.GameData.Get("OwnUnitTable", OwnerIndate, select); //BackEnd Return 데이터 Get.
-    //    var json = BRO.GetReturnValuetoJSON(); //BackEnd Return 데이터 => JSON 데이터로 변환
-    //    playerKillData = new PlayerKillData(json); //PlayerData 클래스에 할당.
-    //    CountTableKey = OwnerIndate;
-    //}
-
     //(임시 양식) 공격력 증가 버튼.
     public void UpAttackButton()
     {
@@ -195,7 +138,7 @@ public class BackEndGetTable : MonoBehaviour
         InitUserAssetTable(); //수정된 UserAssetTable 정보 갱신.
 
         //3단계 수정된 PlayerData 정보 스텟 페이지에 재 할당.
-        MainPage.EditPage(); //스탯 페이지 갱신.
+        //MainPage.EditPage(); //스탯 페이지 갱신.
     }
 
     //임시 공격력 증가 함수.

--- a/BackEnd/BackEndGetTable.cs
+++ b/BackEnd/BackEndGetTable.cs
@@ -17,8 +17,6 @@ public class BackEndGetTable : MonoBehaviour
         InitUserAssetTable(); //자산 테이블 입력.
         InitCaptureCountTable(); //킬카운트 테이블 입력.
 
-        //MainPage = GameObject.Find("@MainScene").GetComponent<MainScene>();//메인 페이지 갱신위한 클래스 할당.
-
         Debug.Log(StatTableKey);
         BackendReturnObject bro = Backend.BMember.GetUserInfo();
         playerStat.OwnerIndate = bro.GetReturnValuetoJSON()["row"]["inDate"].ToString();
@@ -137,7 +135,7 @@ public class BackEndGetTable : MonoBehaviour
         InitUserStatTable(); //수정된 UserTable 정보 갱신.
         InitUserAssetTable(); //수정된 UserAssetTable 정보 갱신.
 
-        //3단계 수정된 PlayerData 정보 스텟 페이지에 재 할당.
+        //3단계 수정된 PlayerData 정보 스텟 페이지에 재 할당. => MainScene 컴포넌트로 기능 이전.
         //MainPage.EditPage(); //스탯 페이지 갱신.
     }
 

--- a/BackEnd/BackEndGetTable.cs
+++ b/BackEnd/BackEndGetTable.cs
@@ -26,6 +26,10 @@ public class BackEndGetTable : MonoBehaviour
         InitCaptureCountTable(); //킬카운트 테이블 입력.
 
         MainPage = GameObject.Find("@MainScene").GetComponent<MainScene>();//메인 페이지 갱신위한 클래스 할당.
+
+        Debug.Log(StatTableKey);
+        BackendReturnObject bro = Backend.BMember.GetUserInfo();
+        playerStat.OwnerIndate = bro.GetReturnValuetoJSON()["row"]["inDate"].ToString();
     }
 
     static void Init()
@@ -145,6 +149,40 @@ public class BackEndGetTable : MonoBehaviour
         CountTableKey = OwnerIndate;
     }
 
+    //포획 유닛 정보 Init
+    //public void InitCaptureUnitTable()
+    //{
+    //    var bro = Backend.GameData.GetMyData("OwnUnitTable", new Where(), 10);
+    //    string OwnerIndate = "";
+    //    if (bro.IsSuccess() == false)
+    //    {
+    //        // 요청 실패 처리
+    //        Debug.Log(bro);
+    //        return;
+    //    }
+    //    if (bro.GetReturnValuetoJSON()["rows"].Count <= 0)
+    //    {
+    //        // 요청이 성공해도 where 조건에 부합하는 데이터가 없을 수 있기 때문에
+    //        // 데이터가 존재하는지 확인
+    //        // 위와 같은 new Where() 조건의 경우 테이블에 row가 하나도 없으면 Count가 0 이하 일 수 있다.
+    //        Debug.Log(bro);
+    //        return;
+    //    }
+    //    //내 테이블의 rowindate 할당.
+    //    for (int i = 0; i < bro.Rows().Count; ++i)
+    //    {
+    //        OwnerIndate = bro.Rows()[i]["inDate"]["S"].ToString();
+    //    }
+    //    string[] select = {"Name"};
+
+    //    // 테이블 내 해당 rowIndate를 지닌 row를 조회
+    //    // select에 존재하는 컬럼만 리턴
+    //    var BRO = Backend.GameData.Get("OwnUnitTable", OwnerIndate, select); //BackEnd Return 데이터 Get.
+    //    var json = BRO.GetReturnValuetoJSON(); //BackEnd Return 데이터 => JSON 데이터로 변환
+    //    playerKillData = new PlayerKillData(json); //PlayerData 클래스에 할당.
+    //    CountTableKey = OwnerIndate;
+    //}
+
     //(임시 양식) 공격력 증가 버튼.
     public void UpAttackButton()
     {
@@ -180,7 +218,6 @@ public class BackEndGetTable : MonoBehaviour
 
     public void AssetUpdate()
     {
-        // atk 컬럼의 값을 110으로 수정
         Param updateParam = new Param();
         updateParam.Add("Coin", playerAsset.Coin);
         updateParam.Add("Spoil1", playerAsset.Spoil1);
@@ -189,5 +226,24 @@ public class BackEndGetTable : MonoBehaviour
         updateParam.Add("Spoil4", playerAsset.Spoil4);
 
         Backend.GameData.Update("UserAssetTable", AssetTableKey, updateParam);
+    }
+
+    public void KillCountUpdate()
+    {
+        Param updateParam = new Param();
+        updateParam.Add("Chicken1", playerKillData.Chicken1);
+        updateParam.Add("Chicken2", playerKillData.Chicken2);
+        updateParam.Add("Chicken3", playerKillData.Chicken3);
+        updateParam.Add("Cow1", playerKillData.Cow1);
+        updateParam.Add("Cow2", playerKillData.Cow2);
+        updateParam.Add("Cow3", playerKillData.Cow1);
+        updateParam.Add("Goat1", playerKillData.Goat1);
+        updateParam.Add("Goat2", playerKillData.Goat2);
+        updateParam.Add("Horse1", playerKillData.Horse1);
+        updateParam.Add("Horse2", playerKillData.Horse2);
+        updateParam.Add("Horse3", playerKillData.Horse3);
+
+
+        Backend.GameData.Update("UnitCaptureCount", CountTableKey, updateParam);
     }
 }

--- a/BackEnd/BackEndGetTable.cs
+++ b/BackEnd/BackEndGetTable.cs
@@ -71,7 +71,7 @@ public class BackEndGetTable : MonoBehaviour
         {
             OwnerIndate = bro.Rows()[i]["inDate"]["S"].ToString();
         }
-        string[] select = { "Attack", "AttackSpeed", "MovingSpeed", "Hp", "Leadership", "Appeal" };
+        string[] select = { "Attack", "AttackSpeed", "MovingSpeed", "Hp", "Leadership", "Appeal", "owner_inDate"};
 
         // 테이블 내 해당 rowIndate를 지닌 row를 조회
         // select에 존재하는 컬럼만 리턴

--- a/Function/AllyCtrl.cs
+++ b/Function/AllyCtrl.cs
@@ -97,6 +97,7 @@ public class AllyCtrl : CreatureCtrl //동료 컨트롤러
     protected override void UpdateDead()
     {
         //죽었을 때 로직
+        Destroy(gameObject);
     }
 
     protected override void DefaultStatDBConnection() //초기 스탯 할당.

--- a/Function/AllyCtrl.cs
+++ b/Function/AllyCtrl.cs
@@ -21,8 +21,6 @@ public class AllyCtrl : CreatureCtrl //동료 컨트롤러
     public UnitData unitData;
     [SerializeField] protected int _level; //유닛의 레벨
     [SerializeField] protected MeadowUnit meadowUnit = MeadowUnit.Null;// 어떤 유닛인지
-    [SerializeField] protected int _dropcoin; //죽으면 주는 돈.
-    [SerializeField] protected int _spoilnumber; //죽으면 주는 전리품 넘버.
 
     protected override void Init()
     {
@@ -44,93 +42,10 @@ public class AllyCtrl : CreatureCtrl //동료 컨트롤러
         //공격 사거리 NavMeshAgent의 stoppingDistance에 적용
         _agent.stoppingDistance = _attackRange;
         _agent.speed = _speed;
+        //팀으로 적을 포획했을 때 아웃라인 원상복귀 코드.
         render = gameObject.GetComponentInChildren<Renderer>();
         render.material.SetFloat("_OutlineWidth", 1.0f);
-        //AbilityByLevel();
     }
-
-    /*
-    private void OnEnable() //활성화 될 때 모든 팀에게 버프 적용
-    {
-        Buff(meadowUnit, true);
-    }
-
-    private void OnDisable() //비 활성화 될 때 모든 팀에게 버프 해제
-    {
-        Buff(meadowUnit, false);
-    }
-    */
-
-    //private void AbilityByLevel() //현재 레벨에 맞는 능력치 적용
-    //{
-    //    switch (meadowUnit)
-    //    {
-    //        case MeadowUnit.Chicken1:
-    //            _hp += (3 * _level);
-    //            break;
-    //        case MeadowUnit.Chicken2:
-    //            _hp += (10 * _level);
-    //            _atk += _level;
-    //            break;
-    //        case MeadowUnit.Chicken3:
-    //            _hp += (3 * _level);
-    //            _atk += (2 * _level);
-    //            break;
-    //        case MeadowUnit.Cow1:
-    //            _hp += (10 * _level);
-    //            break;
-    //        case MeadowUnit.Cow2:
-    //            _hp += (20 * _level);
-    //            break;
-    //        case MeadowUnit.Cow3:
-    //            _hp += (25 * _level);
-    //            break;
-    //        case MeadowUnit.Duck1:
-    //            _hp += (5 * _level);
-    //            _atk += _level;
-    //            break;
-    //        case MeadowUnit.Duck2:
-    //            _hp += (10 * _level);
-    //            _atk += (1.5f * _level);
-    //            break;
-    //        case MeadowUnit.Duck3:
-    //            _hp += (10 * _level);
-    //            _atk += (2 * _level);
-    //            break;
-    //        case MeadowUnit.Horse1:
-    //            _hp += (4 * _level);
-    //            _atk += _level;
-    //            break;
-    //        case MeadowUnit.Horse2:
-    //            _hp += (8 * _level);
-    //            _atk += (1.5f * _level);
-    //            break;
-    //        case MeadowUnit.Horse3:
-    //            _hp += (10 * _level);
-    //            _atk += (2 * _level);
-    //            break;
-    //        case MeadowUnit.Sheep1:
-    //            _hp += (4 * _level);
-    //            _atk += (3 * _level);
-    //            break;
-    //        case MeadowUnit.Sheep2:
-    //            _hp += (5 * _level);
-    //            _atk += (5 * _level);
-    //            break;
-    //        case MeadowUnit.Goat1:
-    //            _hp += (4 * _level);
-    //            _atk += (0.5f * _level);
-    //            _atkSpeed += (0.05f * _level);
-    //            break;
-    //        case MeadowUnit.Goat2:
-    //            _hp += (3 * _level);
-    //            _atk += (1 * _level);
-    //            _atkSpeed += (0.05f * _level);
-    //            break;
-    //        default:
-    //            break;
-    //    }
-    //}
 
     protected override void UpdateController()
     {
@@ -192,20 +107,7 @@ public class AllyCtrl : CreatureCtrl //동료 컨트롤러
         _speed = unitData.Level[_level-1].MovingSpeed;
         _hp = unitData.Level[_level-1].Hp;
         _attackRange = unitData.Level[_level-1].range;
-        _dropcoin = unitData.Level[_level-1].DropCoin;
-        _spoilnumber = unitData.Level[_level-1].Spoilnumber;
         _detectionRange = unitData.Level[_level - 1].DetectionRange;
         _playerRange = unitData.Level[_level - 1].PlayerRange;
-
-    }
-
-    private void OnDrawGizmosSelected()
-    {
-        Gizmos.color = Color.red;
-        Gizmos.DrawWireSphere(transform.position, _detectionRange); //red : 적 발견 범위
-        Gizmos.color = Color.yellow;
-        Gizmos.DrawWireSphere(transform.position, _attackRange); //yellow : 공격 사거리
-        Gizmos.color = Color.green;
-        Gizmos.DrawWireSphere(transform.position, _playerRange); //green : 플레이어와 유닛 내 허용 범위
     }
 }

--- a/Function/CreatureCtrl.cs
+++ b/Function/CreatureCtrl.cs
@@ -128,7 +128,7 @@ public class CreatureCtrl : MonoBehaviour
     }
     protected virtual void UpdateDead()
     {
-
+        Destroy(gameObject);
     }
 
     IEnumerator CoAttack()

--- a/Function/CreatureCtrl.cs
+++ b/Function/CreatureCtrl.cs
@@ -128,7 +128,7 @@ public class CreatureCtrl : MonoBehaviour
     }
     protected virtual void UpdateDead()
     {
-        Destroy(gameObject);
+
     }
 
     IEnumerator CoAttack()

--- a/Function/CreatureCtrl.cs
+++ b/Function/CreatureCtrl.cs
@@ -75,21 +75,16 @@ public class CreatureCtrl : MonoBehaviour
     {
         if (_state == CreatureState.Dead)
         {
-            Debug.Log("333333333");
             StopAllCoroutines();
             _animator.SetTrigger("Dead");
         }
         else if (_state == CreatureState.Moving)
         {
             _animator.Play("Run");
-            //_animator.ResetTrigger("Attack");
-            //_animator.SetTrigger("Run");
         }
         else if (_state == CreatureState.Skill)
         {
             _animator.Play("Attack");
-            //_animator.ResetTrigger("Run");
-            //_animator.SetTrigger("Attack");
         }
         else 
         {
@@ -274,7 +269,6 @@ public class CreatureCtrl : MonoBehaviour
      * FirstOrDefault 메소드는 List 의 첫 번째 요소를 반환. 만약 List 가 비어있다면 null을 반환.
      * 최종적으로 neareastEnemy 변수에 가장 가까운 오브젝트가 저장.
      */
-
     protected GameObject FindNearestObjectByTag(string tag)
     {
         // 탐색할 오브젝트 목록을 List 로 저장

--- a/Function/EnemyCtrl.cs
+++ b/Function/EnemyCtrl.cs
@@ -19,10 +19,6 @@ public class EnemyCtrl : CreatureCtrl
     bool walkPointSet;
     public float walkPointRange;
 
-    //공격.
-    //bool alreadyAttacked;
-    //public GameObject projectile; //원거리 공격 적 위
-
     //State
     public float sightRange; //순찰범위
     public float attackRange; //공격범위
@@ -33,7 +29,8 @@ public class EnemyCtrl : CreatureCtrl
     [SerializeField] protected int _canCapturePercent; //유닛 포획 확률.
     [SerializeField] protected MeadowUnit meadowUnit = MeadowUnit.Null;// 어떤 유닛인지
     [SerializeField] protected int _dropcoin; //죽으면 주는 돈.
-    [SerializeField] protected int _spoilnumber; //죽으면 주는 전리품 넘버.
+    public int _spoilnumber; //죽으면 주는 전리품 넘버(Player가 호출해야 하기 때문에 public). 
+    public int _spoilamount; //죽으면 주는 전리품 양(Player가 호출해야 하기 때문에 public).
     [SerializeField] protected string _enemyname; //Enemy Name
     public UnitData unitData;
     BackEndGetTable GetPlayerStatData;
@@ -74,9 +71,6 @@ public class EnemyCtrl : CreatureCtrl
             if (playerInAttackRange && playerInSightRange) State = CreatureState.Skill; //순찰범위,공격범위 모두 포함되어있을 때
         }
         base.UpdateController();
-        //renderer.material.SetFloat("Alpha", 0.5f);
-        //Color color = renderer.material.color;
-        //color.a = 0.4f;
     }
 
     protected override void UpdateSkill()
@@ -91,7 +85,7 @@ public class EnemyCtrl : CreatureCtrl
         Collider[] cols = Physics.OverlapSphere(gameObject.transform.position, 3);
         foreach (Collider col in cols)
         {
-            if (col.gameObject.layer == LayerMask.NameToLayer("Player")&& gameObject.layer== LayerMask.NameToLayer("Neutrality"))
+            if (col.gameObject.layer == LayerMask.NameToLayer("Player") && gameObject.layer == LayerMask.NameToLayer("Neutrality"))
             {
                 Debug.Log("touch");
                 render.material.SetFloat("_OutlineWidth", 1.15f);
@@ -124,20 +118,18 @@ public class EnemyCtrl : CreatureCtrl
         _attackRange = unitData.Level[0].range;
         _dropcoin = unitData.Level[0].DropCoin;
         _spoilnumber = unitData.Level[0].Spoilnumber;
+        _spoilamount = unitData.Level[0].SpoilAmount;
         _canCapturePercent = unitData.Level[0].CanCapturePercent;
         _enemyname = unitData.Level[0].Name;
     }
 
     public void RandomCapture() //적 죽었을때 포획 or go pool ,  Coin 획득 , KillCount 증가.
     {
-        gameObject.transform.localScale = new Vector3(1.0f, 0.5f, 1.0f);
-        GetPlayerStatData.playerAsset.Coin += _dropcoin; //코인 획득.
- 
-        //여기에 킬카운트 증가 예정.
-
+        gameObject.transform.localScale = new Vector3(1.0f, 0.5f, 1.0f); //죽은 효과를 더 살리게 위해 크기 변경.
+        GetPlayerStatData.playerAsset.Coin += _dropcoin; //몬스터 지정 코인 획득.
+        KillCount(); //킬 카운트 증가.
         int RandomPercent = Random.Range(0, 100);
         int Percent = GetPlayerStatData.playerStat.Appeal + _canCapturePercent; //기존 몬스터 포획 확률 + 플레이어 매력수치 = 포획 확률
-        //render.material.SetFloat("_Outline", 0.3f);
         if (RandomPercent <= Percent) // 포획가능
         {
             Debug.Log("포획 가능");
@@ -147,10 +139,10 @@ public class EnemyCtrl : CreatureCtrl
         else //포획불가능
         {
             Debug.Log("포획 불가능");
-            gameObject.tag = "Enemy1";
+            gameObject.tag = "Enemy1"; 
             gameObject.layer = LayerMask.NameToLayer("Neutrality");
             //알파값 두번 깜빡 거린 후 Pool로 돌아갈 예정.
-            StartCoroutine(BackPool());
+            StartCoroutine(BackPool()); //임시로 Destroy 중 오현이 오브젝트 Pool 구조 완성되면 변경 예정.
         }
     }
 
@@ -200,37 +192,54 @@ public class EnemyCtrl : CreatureCtrl
         Invoke(nameof(ReSpawn), 5f);
     }
 
+    private void KillCount() //몬스터에 따른 킬카운트 증가.
+    {
+        switch (_enemyname)
+        {
+            case "Chicken1":
+                GetPlayerStatData.playerKillData.Chicken1 += 1;
+                break;
+            case "Chicken2":
+                GetPlayerStatData.playerKillData.Chicken2 += 1;
+                break;
+            case "Chicken3":
+                GetPlayerStatData.playerKillData.Chicken3 += 1;
+                break;
+            case "Cow1":
+                GetPlayerStatData.playerKillData.Cow1 += 1;
+                break;
+            case "Cow2":
+                GetPlayerStatData.playerKillData.Cow2 += 1;
+                break;
+            case "Cow3":
+                GetPlayerStatData.playerKillData.Cow3 += 1;
+                break;
+            case "Goat1":
+                GetPlayerStatData.playerKillData.Goat1 += 1;
+                break;
+            case "Goat2":
+                GetPlayerStatData.playerKillData.Goat2 += 1;
+                break;
+            case "Horse1":
+                GetPlayerStatData.playerKillData.Horse1 += 1;
+                break;
+            case "Horse2":
+                GetPlayerStatData.playerKillData.Horse2 += 1;
+                break;
+            case "Horse3":
+                GetPlayerStatData.playerKillData.Horse3 += 1;
+                break;
+            default:
+                break;
+        }
+    }
+
     private void DeactiveDelay() => gameObject.SetActive(false);
     private void ReSpawn() => gameObject.SetActive(true); //Respawn
-
-    //private void OnDrawGizmosSelected() //공격 범위 순찰 범위 영역 보기 위해.
-    //{
-    //    Gizmos.color = Color.red;
-    //    Gizmos.DrawWireSphere(transform.position, attackRange);
-    //    Gizmos.color = Color.yellow;
-    //    Gizmos.DrawWireSphere(transform.position, sightRange);
-    //}
 
     private IEnumerator BackPool()
     {
         yield return new WaitForSeconds(5f);
         Destroy(gameObject);
-        //gameObject.SetActive(false);
     }
-    //private IEnumerator HitAlphaAnimation()
-    //{
-    ////현재 적의 색상.
-    //Color color = renderer.color;
-
-    ////적의 투명도 40퍼센트.
-    //color.a = 0.4f;
-    //renderer.color = color;
-
-    ////0.05초 대기
-    //yield return new WaitForSeconds(0.05f);
-
-    ////적의 투명도 100프로 설정.
-    //color.a = 1.0f;
-    //renderer.color = color;
-    //}
 }

--- a/Function/EnemyCtrl.cs
+++ b/Function/EnemyCtrl.cs
@@ -133,13 +133,13 @@ public class EnemyCtrl : CreatureCtrl
         if (RandomPercent <= Percent) // 포획가능
         {
             Debug.Log("포획 가능");
-            gameObject.tag = "Enemy1";
+            gameObject.tag = "IsDeadEnemy";
             gameObject.layer = LayerMask.NameToLayer("Neutrality");
         }
         else //포획불가능
         {
             Debug.Log("포획 불가능");
-            gameObject.tag = "Enemy1"; 
+            gameObject.tag = "GoPoolEnemy"; 
             gameObject.layer = LayerMask.NameToLayer("Neutrality");
             //알파값 두번 깜빡 거린 후 Pool로 돌아갈 예정.
             StartCoroutine(BackPool()); //임시로 Destroy 중 오현이 오브젝트 Pool 구조 완성되면 변경 예정.

--- a/Function/PlayerCtrl.cs
+++ b/Function/PlayerCtrl.cs
@@ -182,7 +182,7 @@ public class PlayerCtrl : CreatureCtrl
             return;
         }
         //포획 가능.
-        GameObject go = FindNearestObjectByTag("Enemy1"); //  죽어있는상태 가장 가까운 적.
+        GameObject go = FindNearestObjectByTag("IsDeadEnemy"); //  죽어있는상태 가장 가까운 적.
         Destroy(go.GetComponent<EnemyCtrl>());
         AllyCtrl AC = go.AddComponent<AllyCtrl>() as AllyCtrl;
         AC.enabled = true;
@@ -193,7 +193,7 @@ public class PlayerCtrl : CreatureCtrl
 
     public void OnClickGetSpoilButton()
     {
-        GameObject go = FindNearestObjectByTag("Enemy1"); //죽어있는상태 가장 가까운 적(Select).
+        GameObject go = FindNearestObjectByTag("IsDeadEnemy"); //죽어있는상태 가장 가까운 적(Select).
         EnemyCtrl enemyCtrl = go.GetComponent<EnemyCtrl>(); // Select된 적 정보 Get.
         //Get된 정보에 따른 전리품 획득 로직.
         switch(enemyCtrl._spoilnumber)

--- a/Function/PlayerCtrl.cs
+++ b/Function/PlayerCtrl.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using BackEnd;
 using UnityEngine.UI;
 using static Define;
 
@@ -28,6 +29,7 @@ public class PlayerCtrl : CreatureCtrl
 
     public bool _enemyInAttackRange; //공격 사거리 내에 적이 있나요?
     public LayerMask _whatIsEnemy; //enemy 레이어
+    public Transform playertr;
 
     public GameObject ObstacleMinHeight;
     [SerializeField] List<Renderer> list_Obstacle = new List<Renderer>(); //플레이어를 가리는 오브젝트의 Renderer
@@ -35,10 +37,12 @@ public class PlayerCtrl : CreatureCtrl
 
     private int _leadership;
     private int _appeal;
-    //new private int _attackRange = 4;
 
     public GameObject _captureButton;
     public GameObject _getSpoilButton;
+
+    //BackEnd 연동 위한 Get String My ID
+    private string OwnerIndateKey;
 
     protected override void Init()
     {
@@ -53,6 +57,20 @@ public class PlayerCtrl : CreatureCtrl
     {
         rb = _creature.GetComponent<Rigidbody>(); 
         base.Init2();
+        //Player가 가지고 있는 Creature Name,Count 조회.
+        Where where = new Where();
+        where.Equal("owner_inDate", GetPlayerStatData.playerStat.OwnerIndate);
+        var bro = Backend.GameData.GetMyData("OwnUnitTable", where, 50);
+        Debug.Log(bro.GetReturnValuetoJSON()["rows"].Count);
+        for(int i=0; i< bro.GetReturnValuetoJSON()["rows"].Count; i++) //(임시코드)가지고 있는 Creature 수까지 반복. 게임씬에는 생성.디비 테이블에선 삭제.
+        {
+            string Name = bro.Rows()[0]["Name"]["S"].ToString();
+            GameObject go = Managers.Resource.Instantiate($"Creature_YJ/{Name}");
+            Destroy(go.GetComponent<EnemyCtrl>());
+            AllyCtrl AC = go.AddComponent<AllyCtrl>() as AllyCtrl;
+            AC.enabled = true;
+            Backend.GameData.Delete("OwnUnitTable", where);
+        }
     }
 
     protected override void UpdateAnimation() //공격과 죽음만 애니메이션 구현
@@ -92,7 +110,7 @@ public class PlayerCtrl : CreatureCtrl
                 if (list_Obstacle.Count != 0) ReleaseAlpha();
             }
         }
-        if (Input.GetKeyDown(KeyCode.Q)) GoMain();
+        if (Input.GetKeyDown(KeyCode.Q)) GoMain(); //(임시) 메인씬 가는 코드.
     }
 
     protected override void UpdateDead()
@@ -175,26 +193,82 @@ public class PlayerCtrl : CreatureCtrl
 
     public void OnClickGetSpoilButton()
     {
-        GameObject go = FindNearestObjectByTag("Enemy1"); //  죽어있는상태 가장 가까운 적.
-        Destroy(go);
-        GetPlayerStatData.playerAsset.Spoil1 += 1;
+        GameObject go = FindNearestObjectByTag("Enemy1"); //죽어있는상태 가장 가까운 적(Select).
+        EnemyCtrl enemyCtrl = go.GetComponent<EnemyCtrl>(); // Select된 적 정보 Get.
+        //Get된 정보에 따른 전리품 획득 로직.
+        switch(enemyCtrl._spoilnumber)
+        {
+            case 1:
+                GetPlayerStatData.playerAsset.Spoil1 += enemyCtrl._spoilamount;
+                break;
+            case 2:
+                GetPlayerStatData.playerAsset.Spoil2 += enemyCtrl._spoilamount;
+                break;
+            case 3:
+                GetPlayerStatData.playerAsset.Spoil3 += enemyCtrl._spoilamount;
+                break;
+            default:
+                break;
+        }
         //Enemy pool로 돌아가는 로직 임시로 Destroy.
+        Destroy(go);
         OffCaptureButton(); //버튼 off
         OffGetSpoilButton(); //버튼 off
     }
 
     public void GoMain() // 임시로 메인씬으로 돌아가는 로직, 디비 값 조정.
     {
-        GetPlayerStatData.GetComponent<BackEndGetTable>().AssetUpdate(); //자산테이블 업데이트.블
-
+        GetPlayerStatData.GetComponent<BackEndGetTable>().AssetUpdate(); //자산 테이블 업데이트.
+        GetPlayerStatData.GetComponent<BackEndGetTable>().KillCountUpdate();//킬 카운트 테이블 업데이트.
+        InsertOwnUnitTable(); //OwnCreature Table 업데이트.
         Managers.Scene.LoadScene(Define.Scene.Main);
     }
 
     public void OnApplicationQuit() //게임씬에서 앱 강제 종료시 호출되는 함수, 디비 값 조정.
     {
         GetPlayerStatData.GetComponent<BackEndGetTable>().AssetUpdate(); //자산테이블 업데이트.
+        GetPlayerStatData.GetComponent<BackEndGetTable>().KillCountUpdate();//킬 카운트 테이블 업데이트.
+        InsertOwnUnitTable(); //OwnCreature Table 업데이트. 
+    }
+
+    public void InsertOwnUnitTable()
+    {
+        // Param은 뒤끝 서버와 통신을 할 떄 넘겨주는 파라미터 클래스 입니다.
+        GameObject[] Ally = GameObject.FindGameObjectsWithTag("Team"); //동료 숫자 파악.
+        for (int i = 0; i < Ally.Length; i++)
+        {
+            if (Ally[i].gameObject.name != "player")
+            {
+                Param param = new Param();
+                param.Add("Name", Ally[i].gameObject.name);
+
+                BackendReturnObject BRO = Backend.GameData.Insert("OwnUnitTable", param);
+                if (BRO.IsSuccess())
+                {
+                    Debug.Log("indate : " + BRO.GetInDate());
+                }
+                else
+                {
+                    switch (BRO.GetStatusCode())
+                    {
+                        case "404":
+                            Debug.Log("존재하지 않는 tableName인 경우");
+                            break;
+
+                        case "412":
+                            Debug.Log("비활성화 된 tableName인 경우");
+                            break;
+
+                        case "413":
+                            Debug.Log("하나의 row( column들의 집합 )이 400KB를 넘는 경우");
+                            break;
+
+                        default:
+                            Debug.Log("서버 공통 에러 발생: " + BRO.GetMessage());
+                            break;
+                    }
+                }
+            }
+        }
     }
 }
-
-//공격사거리 근처에만 있으면 공격. 
-

--- a/Scenes/MainScene.cs
+++ b/Scenes/MainScene.cs
@@ -6,7 +6,9 @@ using BackEnd;
 
 public class MainScene : BaseScene
 {
-    public BackEndGetTable GetTable;
+    //BackEndGetTable 싱글톤 보장 받기위한 Static 변수.
+    static BackEndGetTable s_instance; //유일성이 보장된다.
+    static BackEndGetTable Instance { get { TableInit(); return s_instance; } }
 
     [Header ("UserStatText")]
     [SerializeField] private Text Attack;
@@ -26,8 +28,22 @@ public class MainScene : BaseScene
     void Start()
     {
         Init();
-        GetTable = GameObject.Find("UserTableInformation").GetComponent<BackEndGetTable>();
+        TableInit();
         EditPage();
+    }
+    static void TableInit() // 유저 DB정보 싱글톤 할당.
+    {
+        if (s_instance == null)
+        {
+            GameObject go = GameObject.Find("UserTableInformation");
+            if (go == null)
+            {
+                go = new GameObject { name = "UserTableInformation" };
+                go.AddComponent<BackEndGetTable>();
+            }
+            DontDestroyOnLoad(go);
+            s_instance = go.GetComponent<BackEndGetTable>();
+        }
     }
 
     protected override void Init()
@@ -45,22 +61,27 @@ public class MainScene : BaseScene
     {
         Managers.Scene.LoadScene(Define.Scene.Game);
     }
+    public void OnClickUPAttack()
+    {
+        s_instance.UpAttackButton(); // 싱글톤 테이블 instance.공격력Up 함수.
+        EditPage(); //페이지 재할당.
+    }
 
     public void EditPage()
     {
         //Stat Text 할당.
-        Attack.text = GetTable.playerStat.Attack.ToString();
-        AttackSpeed.text = GetTable.playerStat.AttackSpeed.ToString();
-        MovingSpeed.text = GetTable.playerStat.MovingSpeed.ToString();
-        Hp.text = GetTable.playerStat.Hp.ToString();
-        Leadership.text = GetTable.playerStat.Leadership.ToString();
-        Appeal.text = GetTable.playerStat.Appeal.ToString();
+        Attack.text = s_instance.playerStat.Attack.ToString();
+        AttackSpeed.text = s_instance.playerStat.AttackSpeed.ToString();
+        MovingSpeed.text = s_instance.playerStat.MovingSpeed.ToString();
+        Hp.text = s_instance.playerStat.Hp.ToString();
+        Leadership.text = s_instance.playerStat.Leadership.ToString();
+        Appeal.text = s_instance.playerStat.Appeal.ToString();
 
         //Asset Text 할당.
-        Coin.text = GetTable.playerAsset.Coin.ToString();
-        Spoil1.text = GetTable.playerAsset.Spoil1.ToString();
-        Spoil2.text = GetTable.playerAsset.Spoil2.ToString();
-        Spoil3.text = GetTable.playerAsset.Spoil3.ToString();
-        Spoil4.text = GetTable.playerAsset.Spoil4.ToString();
+        Coin.text = s_instance.playerAsset.Coin.ToString();
+        Spoil1.text = s_instance.playerAsset.Spoil1.ToString();
+        Spoil2.text = s_instance.playerAsset.Spoil2.ToString();
+        Spoil3.text = s_instance.playerAsset.Spoil3.ToString();
+        Spoil4.text = s_instance.playerAsset.Spoil4.ToString();
     }
 }

--- a/Scenes/MainScene.cs
+++ b/Scenes/MainScene.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using BackEnd;

--- a/Utils/PlayerData.cs
+++ b/Utils/PlayerData.cs
@@ -12,6 +12,7 @@ public class PlayerStatData
     public int Hp;
     public int Leadership;
     public int Appeal;
+    public string OwnerIndate;
 
     public PlayerStatData(JsonData json) //JSON Data 할당 생성자.  
     {

--- a/Utils/PlayerData.cs
+++ b/Utils/PlayerData.cs
@@ -22,6 +22,7 @@ public class PlayerStatData
         this.Hp = int.Parse(json["row"]["Hp"]["N"].ToString());
         this.Leadership = int.Parse(json["row"]["Leadership"]["N"].ToString());
         this.Appeal = int.Parse(json["row"]["Appeal"]["N"].ToString());
+        this.OwnerIndate = json["row"]["owner_inDate"]["S"].ToString();
     }
 }
 

--- a/Utils/UnitData.cs
+++ b/Utils/UnitData.cs
@@ -22,6 +22,7 @@ public class UnitData : ScriptableObject
         public int range;   // 사거리
         public int DropCoin;    //죽으면 죽는 돈.
         public int Spoilnumber; // 죽으면 주는 전리품 넘버.
+        public int SpoilAmount; //죽으면 주는 전리품 양.
         public int CanCapturePercent; //죽었을 시 포획 가능 확률.
         public int DetectionRange; //적 발견 사거리
         public int PlayerRange; //플레이어와 동료 사거리


### PR DESCRIPTION
### Description
1. 전에 구현 해둔 적 포획 로직 & 전리품 획득 로직 => 뒤끝 빽엔드 연동.
2. BackEndGetTable(DB 싱글톤 정보) 로직 변경 =>
기존 MainScene 필드에 깔아둔 UserTableInformation(싱글톤 객체) -> MainScene에 들어갈 시 생성하는 로직으로 변경(싱글톤 보장)
3. Unit 별 KillCount DB 연동.(차후에 UnitData level 기획 예정)
